### PR TITLE
Added support for streaming metrics

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,6 @@ jobs:
         shell: bash
 
     steps:
-      # Checkout the repository to the GitHub Actions runner
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -26,9 +25,9 @@ jobs:
 
       - name: Find version
         id: version
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/tags/v}
+        run: echo "MODULE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
 
       - id: publish
         name: Publish
         run: |
-          nullstone modules publish --version=${{ steps.version.outputs.tag }}
+          nullstone modules publish --version=${{ env.MODULE_VERSION }}

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,123 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/datadog/datadog" {
+  version = "3.31.0"
+  hashes = [
+    "h1:IgiJkTB3sZOoOTRgjHXSrAGKHz113Fbkyg3Xa3b4QBk=",
+    "h1:KCGJHohZL8+hzW/B7QvmHWKUpSYSKSgMm3RfOXa1nqE=",
+    "h1:S2DFaeRqdKSbTXMLiapmJI9tdkQdHIC8ANhdWPgzVZ8=",
+    "h1:j2mXs7mvhl/sTaxWY/9meLQbRplx8zc0nFDIe4K6bc0=",
+    "h1:ndPQbATmMnXJ7IfRN9V8ZqyaVOFRXJ/Wuk6XVa9g8W4=",
+    "zh:1c5f6b659b10634153113e1a4b587f5eab0eb75c5e3d1eeb35cda3dfcc7f33a1",
+    "zh:2518b0d169ad5ddf9d2f965bfd7e77f9cabd9daf33c54311ea24933c867f1460",
+    "zh:2759cc59aaf9d8a8b7096500fa5cf236ffb4749b408399e3ff4918ed22a0907f",
+    "zh:2be2e98b282670bce20fa65f04618ed0a23869bf8d6d9ea4d5d963a6f564ee15",
+    "zh:61f88e5711e8dd2faa4c62135daeeeda8a739cc874bd92899f6f84574f7bd622",
+    "zh:6a18de5a48c679755eff48452d1d1481f231d590e4424947c752005edf7a33fd",
+    "zh:6e5cbbc93afb550825cde73665287e2776262ea1fb9121b85a245905183b6357",
+    "zh:7133ab10cd4a1dd20022ea76addd6dbc981394e3acafc89cd73eab2beb8bbcac",
+    "zh:72fdcf7d99078447d80c68f250d0c5c8c0817be01e187d76f1729ebb606b61fc",
+    "zh:a4ee097d837b80a439fd2913f1aa9d20f8d7dc8cb23706e3c2e2f8cf974ce834",
+    "zh:b90bcbba2ff7fca44893782b87c574382f4b3f56f3c8c6745aa666230da65412",
+    "zh:bd30440e64dbdd6a5c5b523282fb3249af907a835cad97fdd8a574b71f89de89",
+    "zh:f1f31f70902560813f25fde8bf906922a772e0a87b391f56008bcd33d051a3ff",
+    "zh:f358c936412c694df7b20f9f43364dbb8faa9abf58e32a59ba44618c15a7a1b9",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.22.0"
+  hashes = [
+    "h1:4oAjE3Fn/vXruaORPWH1lH7q/+oPEqxNm6+KjOMeMrI=",
+    "h1:XuU3tsGzElMt4Ti8SsM05pFllNMwSC4ScUxcfsOS140=",
+    "h1:bNRGSiw+XvdXgU94N0fto22cwPY3tfxdrqC/19X0RVw=",
+    "h1:s5D2g7z2dt8mqIwnQAjyE6NZWEirfRxt7kLsmslY5Ls=",
+    "h1:ucoUpPuJUrtC5PxO3TpES2yQ7cMWZlfIQCbIbEwen94=",
+    "zh:09b8475cd519c945423b1e1183b71a4209dd2927e0d289a88c5abeecb53c1753",
+    "zh:2448e0c3ce9b991a5dd70f6a42d842366a6a2460cf63b31fb9bc5d2cc92ced19",
+    "zh:3b9fc2bf6714a9a9ab25eae3e56cead3d3917bc1b6d8b9fb3111c4198a790c72",
+    "zh:4fbd28ad5380529a36c54d7a96c9768df1288c625d28b8fa3a50d4fc2176ef0f",
+    "zh:54d550f190702a7edc2d459952d025e259a8c0b0ff7df3f15bbcc148539214bf",
+    "zh:638f406d084ac96f3a0b0a5ce8aa71a5a2a781a56ba96e3a235d3982b89eef0d",
+    "zh:69d4c175b13b6916b5c9398172cc384e7af46cb737b45870ab9907f12e82a28a",
+    "zh:81edec181a67255d25caf5e7ffe6d5e8f9373849b9e8f5e0705f277640abb18e",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a66efb2b3cf7be8116728ae5782d7550f23f3719da2ed3c10228d29c44b7dc84",
+    "zh:ae754478d0bfa42195d16cf46091fab7c1c075ebc965d919338e36aed45add78",
+    "zh:e0603ad0061c43aa1cb52740b1e700b8afb55667d7ee01c1cc1ceb6f983d4c9d",
+    "zh:e4cb701d0185884eed0492a66eff17251f5b4971d30e81acd5e0a55627059fc8",
+    "zh:f7db2fcf69679925dde1ae326526242fd61ba1f83f614b1f6d9d68c925417e51",
+    "zh:fef331b9b62bc26d900ae937cc662281ff30794edf48aebfe8997d0e16835f6d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:3hjTP5tQBspPcFAJlfafnWrNrKnr7J4Cp0qB9jbqf30=",
+    "h1:6FVyQ/aG6tawPam6B+oFjgdidKd83uG9n7dOSQ66HBA=",
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
+    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
+    "h1:sZ7MTSD4FLekNN2wSNFGpM+5slfvpm5A/NLVZiB7CO0=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}
+
+provider "registry.terraform.io/nullstone-io/ns" {
+  version = "0.6.22"
+  hashes = [
+    "h1:1pJP5/RweaOf8v5uWVLyIIO9+yKMcY0GdRZiADGZMWc=",
+    "h1:T80dWkdEuI69zRY2UXm255iW+2UiedaNsuARrLp/3OY=",
+    "h1:TOVxLHvpui8TZ3/ehqJe6hcKeETSTTbIGtGTloO2/Pc=",
+    "h1:XOyqJRPTzXpSgkZGQvbmyzTKbvPNsI8smkQsc2sZKMA=",
+    "h1:aMFqeu5KNBrJVN9w7fQFZHG+dF95BMxEKmBWKfRMjfQ=",
+    "zh:003ead5999768765dc0b9a0becaaddd6c8f1088b115f29604f6aaa2dc6e12f29",
+    "zh:10cf75e381320ed161a70d70fa87d59bd42810666cba62c81cb3e13c9bab8998",
+    "zh:28a9efb91fe63dad2c125fd4ff024acfad2c7f33d8f966e138693ad54da84fc7",
+    "zh:48058858531a60408fc9cfd0b5a118797b53bb83fe68d1d42706b38ee12c3e5b",
+    "zh:6cdb78a5d73b929f58c9f70cdb5fec69e0b861a3b620018715faa80d0487a387",
+    "zh:8814db8f832b37a8e3d318d8942a29ca310ed9a1737f40612a3d05a6113a23e9",
+    "zh:9d105689d10cfcfe32221aed5593c67ab7dba5365773cb0c0a518f7cac81de73",
+    "zh:ad187f7db65e81379cd48efeb4889f3e2d14f476d5a18ce63d623d0f45ea1b85",
+    "zh:bcea05968f4f17e643eb96aeffdb5b53dcc2debfece8dd18899cfe894e816bef",
+    "zh:ce36676f6ca6884d0fc993873245b8a2902758e582a371ecce1bf4f7b27eabcf",
+    "zh:d96e0432dcbba73ac97b86a86dc3cdf5d6bfdd7a201893e7e61c2382e99750c2",
+    "zh:ea357c702917049dbc249eb6fa22b8906ee4d47335c92717e9e2910fdc429290",
+    "zh:ec062b98f2bd7d149ae98c8a7d791a95fe0f5d7aac4907e95f73f077b08a33a6",
+    "zh:f24ab46165449884ed8e761b005fb0be0e3c72382d94d1fd230871b5e12ea331",
+  ]
+}
+
+provider "registry.terraform.io/tlkamp/validation" {
+  version = "1.0.0"
+  hashes = [
+    "h1:yt/qnD3czEM2oymIuJDU/XiGoC6snlZ2vvYeRjov5hg=",
+    "zh:1187fdfbc7723b47ec05d51c0c35df6414b18ab5e57ab361a875b99f520b1ad5",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:298de3ee386d828cb6af03083a286b0f2d05ceceefabd31cbf87834fdecd7aed",
+    "zh:44c55d1c307c4c38fb88e6cf7314ea313d631f6ce17e03da2153e3de521ff223",
+    "zh:50fbbbeda764d78282bc09bf258016b35afd2b45c7722b28820acc60af59875d",
+    "zh:56daf570ee7775cf80985a6bcf621b484e0eb612c50614d1ce488f1ff0b298ca",
+    "zh:5c582a9bda6d9aa117f9f9540909450e1b4601d427c679e2acd39e762d422617",
+    "zh:6b203b18d33d40ea53f7f2af04de2f0cff26ff65954e7f1dbf50dcdc35b5accc",
+    "zh:78afa61d7e89c62f10441a345f98f3e0223615fa1b3e6324dcb683eb20694888",
+    "zh:b1f38960fb0da66ab2a63aae42e44c94167a209620e76d8bace5618434c1d03e",
+    "zh:c62092e0c2ac0b6d24c02557816c773da723c9473fa614a8b41081b0b5e80792",
+    "zh:cb41c79a079f24c2639faf03b548ed491b8bdbdc245e06c9b51df4e787b7e785",
+    "zh:d8f809c3232f3125bd91ca66d7143a468be9bac71694509563ada8258fff8aec",
+    "zh:e488a24b8e359e8c761928418084fef637ead17871c2fe21e46d78460f202483",
+    "zh:fb9ce71b239e0ee669a85a230de1930e5cfeacec47425444989f9dd7cae1f18a",
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+# 0.1.0 (Jun 04, 2024)
+* Initial release

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+lock-providers:
+	terraform providers lock -platform=linux_amd64 -platform=linux_arm64 -platform=darwin_amd64 -platform=darwin_arm64 -platform=windows_amd64

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# aws-datadog-fargate
-Capability to report logs and metrics for an AWS fargate service to Datadog
+# Datadog Logs/Metrics for ECS/Fargate
+
+This capability sends application logs and metrics to Datadog for ECS (Fargate-based or EC2-based).
+
+## Logs
+
+Application logs are configured to send to Datadog in near real-time. (<1 min latency)
+These logs are tagged with `stack`, `block`, and `env`.
+
+The application logs are immediately sent to Cloudwatch and transmitted to Datadog via Kinesis Firehose.
+
+## Metrics
+
+The Datadog agent is added to your application as a sidecar container.
+This agent collects metrics from AWS and custom metrics from your application and sends them to Datadog in near real-time.

--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ The application logs are immediately sent to Cloudwatch and transmitted to Datad
 
 The Datadog agent is added to your application as a sidecar container.
 This agent collects metrics from AWS and custom metrics from your application and sends them to Datadog in near real-time.
+
+### OpenTelemetry
+
+The Datadog agent is configured as an OpenTelemetry agent with a gRPC listener on port 4317 and HTTP listener on port 4318.
+This module automatically injects `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable into the app.
+This endpoint refers to the HTTP listener.

--- a/agent.tf
+++ b/agent.tf
@@ -1,0 +1,41 @@
+output "sidecars" {
+  value = [
+    {
+      name         = "datadog-agent"
+      image        = "public.ecr.aws/datadog/agent:latest"
+      essential    = true
+      portMappings = [
+        { protocol = "tcp", containerPort = 8126 },
+      ]
+      environment  = [
+        { name = "ECS_FARGATE", value = "true" },
+        { name = "DD_APM_ENABLED", value = "true" },
+        { name = "DD_SITE", value = "datadoghq.com" }
+      ]
+      secrets = [{ name = "DD_API_KEY", valueFrom = local.api_key_secret_id }]
+    }
+  ]
+}
+
+resource "aws_iam_role_policy_attachment" "execution-datadog" {
+  role       = local.execution_role_name
+  policy_arn = aws_iam_policy.datadog.arn
+}
+
+resource "aws_iam_policy" "datadog" {
+  name   = "${local.resource_name}-datadog"
+  policy = data.aws_iam_policy_document.datadog.json
+}
+
+data "aws_iam_policy_document" "datadog" {
+  statement {
+    sid       = "AllowReadDatadogApiKey"
+    effect    = "Allow"
+    resources = [local.api_key_secret_id]
+
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "kms:Decrypt"
+    ]
+  }
+}

--- a/agent.tf
+++ b/agent.tf
@@ -1,20 +1,23 @@
-output "sidecars" {
-  value = [
-    {
-      name         = "datadog-agent"
-      image        = "public.ecr.aws/datadog/agent:latest"
-      essential    = true
-      portMappings = jsonencode([
-        { protocol = "tcp", containerPort = 8126 },
-      ])
-      environment  = jsonencode([
-        { name = "ECS_FARGATE", value = "true" },
-        { name = "DD_APM_ENABLED", value = "true" },
-        { name = "DD_SITE", value = "datadoghq.com" }
-      ])
-      secrets = jsonencode([{ name = "DD_API_KEY", valueFrom = local.api_key_secret_id }])
-    }
-  ]
+locals {
+  sidecar_name = "datadog-agent"
+  agent_sidecar = {
+    name      = "datadog-agent"
+    image     = "public.ecr.aws/datadog/agent:latest"
+    essential = true
+    portMappings = jsonencode([
+      { protocol = "tcp", containerPort = 4317 },
+      { protocol = "tcp", containerPort = 4318 },
+      { protocol = "tcp", containerPort = 8126 },
+    ])
+    environment = jsonencode([
+      { name = "ECS_FARGATE", value = "true" },
+      { name = "DD_APM_ENABLED", value = "true" },
+      { name = "DD_SITE", value = "datadoghq.com" },
+      { name = "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT", value = "0.0.0.0:4317" },
+      { name = "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT", value = "0.0.0.0:4318" }
+    ])
+    secrets = jsonencode([{ name = "DD_API_KEY", valueFrom = local.api_key_secret_id }])
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "execution-datadog" {

--- a/agent.tf
+++ b/agent.tf
@@ -4,15 +4,15 @@ output "sidecars" {
       name         = "datadog-agent"
       image        = "public.ecr.aws/datadog/agent:latest"
       essential    = true
-      portMappings = [
+      portMappings = jsonencode([
         { protocol = "tcp", containerPort = 8126 },
-      ]
-      environment  = [
+      ])
+      environment  = jsonencode([
         { name = "ECS_FARGATE", value = "true" },
         { name = "DD_APM_ENABLED", value = "true" },
         { name = "DD_SITE", value = "datadoghq.com" }
-      ]
-      secrets = [{ name = "DD_API_KEY", valueFrom = local.api_key_secret_id }]
+      ])
+      secrets = jsonencode([{ name = "DD_API_KEY", valueFrom = local.api_key_secret_id }])
     }
   ]
 }

--- a/datadog.tf
+++ b/datadog.tf
@@ -4,7 +4,7 @@ data "ns_connection" "datadog" {
 }
 
 locals {
-  delivery_stream_arn = data.ns_connection.datadog.outputs.delivery_stream_arn
+  delivery_stream_arn = data.ns_connection.datadog.outputs.logs_delivery_stream_arn
   delivery_role_arn   = data.ns_connection.datadog.outputs.delivery_role_arn
   datadog_region      = data.ns_connection.datadog.outputs.datadog_region
   api_key_secret_id   = data.ns_connection.datadog.outputs.api_key_secret_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,7 +2,7 @@ output "env" {
   value = [
     {
       name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
-      value = "http://${local.sidecar_name}:4318"
+      value = "http://localhost:4318"
     }
   ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,14 @@
-output "noop" {
-  value = []
+output "env" {
+  value = [
+    {
+      name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
+      value = "http://${local.sidecar_name}:4318"
+    }
+  ]
+}
+
+output "sidecars" {
+  value = [
+    local.agent_sidecar
+  ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,5 +9,6 @@ EOF
 }
 
 locals {
-  log_group_name = var.app_metadata["log_group_name"]
+  log_group_name      = var.app_metadata["log_group_name"]
+  execution_role_name = var.app_metadata["execution_role_name"]
 }


### PR DESCRIPTION
This enhances the Datadog capability to add a Datadog agent sidecar. This sidecar automatically emits standard metrics and configures the agent to listen as an OpenTelemetry collector.